### PR TITLE
[coq] Coq Updates:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 *.cmx
 *.cmxs
 *.cmxa
+src.8.10/abstraction.ml

--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
-FLG -rectypes -thread -w @1..50@59-4-44 -safe-string -open API
+FLG -rectypes -thread -w @1..50@59-4-44
 
 S src
 B src

--- a/Make.cfg
+++ b/Make.cfg
@@ -5,5 +5,5 @@ src.version/debug.ml
 src.version/parametricity.ml
 src.version/relations.ml
 src.version/declare_translation.ml
-src.version/abstraction.ml4
+src.version/abstraction.coqpp_ext
 src.version/paramcoq.mlpack

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,19 @@ src.$(COQVV)/paramcoq_mod.ml: src.$(COQVV)/paramcoq.mlpack
 
 pre-makefile:: src.$(COQVV)/paramcoq_mod.ml
 
+ifeq (, $(shell which coqpp))
+ PPEXT=ml4
+else
+ # 8.9 doesn't supports the attribute coqpp syntax
+ ifeq ($(COQVV),8.9)
+   PPEXT=ml4
+ else
+   PPEXT=mlg
+ endif
+endif
+
 Make.cfg.local: Make.cfg
-	sed -e "s/src.version/src.$(COQVV)/" $< > $@
+	sed -e "s/src.version/src.$(COQVV)/;s/coqpp.ext/$(PPEXT)/" $< > $@
 
 ifeq ($(COQVV),8.7)
 this-config::

--- a/src.8.10/abstraction.mlg
+++ b/src.8.10/abstraction.mlg
@@ -1,3 +1,4 @@
+{
 (**************************************************************************)
 (*                                                                        *)
 (*     ParamCoq                                                           *)
@@ -9,141 +10,144 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(*i camlp4deps: "src/parametricity.cmo" "src/declare_translation.cmo" i*)
+}
 
 DECLARE PLUGIN "parametricity"
 
+{
 open Ltac_plugin
 open Feedback
 open Stdarg
 open Tacarg
 open Parametricity
 open Declare_translation
+open Attributes
+}
 
 VERNAC COMMAND EXTEND SetParametricityTactic CLASSIFIED AS SIDEFF
-| [ "Parametricity" "Tactic" ":=" tactic(t) ] -> [
-    let atts = Attributes.attributes_of_flags atts in
+| #[ locality; ]
+  [ "Parametricity" "Tactic" ":=" tactic(t) ] -> {
     Relations.set_parametricity_tactic
-      (Locality.make_section_locality atts.Attributes.locality)
-      (Tacintern.glob_tactic t) ]
+      (Locality.make_section_locality locality)
+      (Tacintern.glob_tactic t) }
 END
 
 VERNAC COMMAND EXTEND ShowTable CLASSIFIED AS QUERY
-| [ "Show" "Parametricity" "Table" ] -> [
+| [ "Show" "Parametricity" "Table" ] -> {
   Relations.print_relations ()
-]
+}
 END
 
 VERNAC COMMAND EXTEND ShowParametricityTactic CLASSIFIED AS QUERY
-| [ "Show" "Parametricity" "Tactic" ] -> [
-   Pp.(msg_info (str "Paramericity obligation tactic is " ++ Relations.print_parametricity_tactic ())) ]
+| [ "Show" "Parametricity" "Tactic" ] -> {
+   Pp.(msg_info (str "Paramericity obligation tactic is " ++ Relations.print_parametricity_tactic ())) }
 END
 
 VERNAC COMMAND EXTEND ParametricityDefined CLASSIFIED AS SIDEFF
-| [ "Parametricity" "Done"  ] -> [
+| [ "Parametricity" "Done"  ] -> {
     parametricity_close_proof ()
-]
+}
 END
 
 VERNAC COMMAND EXTEND AbstractionReference CLASSIFIED AS SIDEFF
-| [ "Parametricity" ref(c) ] -> 
-  [
-    command_reference default_arity (Constrintern.intern_reference c) None  
-  ]
-| [ "Parametricity" reference(c) "as" ident(name)] -> 
-  [
+| [ "Parametricity" ref(c) ] ->
+  {
+    command_reference default_arity (Constrintern.intern_reference c) None
+  }
+| [ "Parametricity" reference(c) "as" ident(name)] ->
+  {
     command_reference default_arity (Constrintern.intern_reference c) (Some name)
-  ]
+  }
 | [ "Parametricity" reference(c) "qualified" ] ->
-  [
+  {
     command_reference ~fullname:true default_arity (Constrintern.intern_reference c) None
-  ]
-| [ "Parametricity" reference(c) "arity" int(arity) ] -> 
-  [
-    command_reference arity (Constrintern.intern_reference c) None  
-  ]
+  }
+| [ "Parametricity" reference(c) "arity" int(arity) ] ->
+  {
+    command_reference arity (Constrintern.intern_reference c) None
+  }
 | [ "Parametricity" reference(c) "arity" int(arity) "as" ident(name) ] ->
-  [
-    command_reference arity (Constrintern.intern_reference c) (Some name)  
-  ]
+  {
+    command_reference arity (Constrintern.intern_reference c) (Some name)
+  }
 | [ "Parametricity" reference(c) "arity" int(arity) "qualified" ] ->
-  [
+  {
     command_reference ~fullname:true arity (Constrintern.intern_reference c) None
-  ]
-| [ "Parametricity" reference(c)  "as" ident(name) "arity" integer(arity) ] -> 
-  [
-    command_reference arity (Constrintern.intern_reference c) (Some name)  
-  ]
-END 
+  }
+| [ "Parametricity" reference(c)  "as" ident(name) "arity" integer(arity) ] ->
+  {
+    command_reference arity (Constrintern.intern_reference c) (Some name)
+  }
+END
 
 VERNAC COMMAND EXTEND AbstractionRecursive CLASSIFIED AS SIDEFF
-| [ "Parametricity" "Recursive" reference(c) ] -> 
-  [
+| [ "Parametricity" "Recursive" reference(c) ] ->
+  {
     command_reference_recursive default_arity (Constrintern.intern_reference c)
-  ]
-| [ "Parametricity" "Recursive" reference(c) "arity" integer(arity) ] -> 
-  [
+  }
+| [ "Parametricity" "Recursive" reference(c) "arity" integer(arity) ] ->
+  {
     command_reference_recursive arity (Constrintern.intern_reference c)
-  ]
+  }
 | [ "Parametricity" "Recursive" reference(c) "qualified" ] ->
-  [
+  {
     command_reference_recursive ~fullname:true default_arity (Constrintern.intern_reference c)
-  ]
+  }
 | [ "Parametricity" "Recursive" reference(c) "arity" integer(arity) "qualified" ] ->
-  [
+  {
     command_reference_recursive ~fullname:true arity (Constrintern.intern_reference c)
-  ]
+  }
 END
 
 VERNAC COMMAND EXTEND Abstraction CLASSIFIED AS SIDEFF
-| [ "Parametricity" "Translation" constr(c) "as" ident(name)] -> 
-  [
+| [ "Parametricity" "Translation" constr(c) "as" ident(name)] ->
+  {
     translate_command default_arity c name
-  ] 
-| [ "Parametricity" "Translation" constr(c) "as" ident(name) "arity" integer(arity) ] -> 
-  [
-    translate_command arity c name 
-  ]
-| [ "Parametricity" "Translation" constr(c) "arity" integer(arity) "as" ident(name)] -> 
-  [
-    translate_command arity c name 
-  ]
+  }
+| [ "Parametricity" "Translation" constr(c) "as" ident(name) "arity" integer(arity) ] ->
+  {
+    translate_command arity c name
+  }
+| [ "Parametricity" "Translation" constr(c) "arity" integer(arity) "as" ident(name)] ->
+  {
+    translate_command arity c name
+  }
 END
 
 VERNAC COMMAND EXTEND TranslateModule CLASSIFIED AS SIDEFF
 | [ "Parametricity" "Module" global(qid) ] ->
-  [
+  {
     ignore (translate_module_command Parametricity.default_arity qid)
-  ]
+  }
 | [ "Parametricity" "Module" global(qid) "as" ident(name) ] ->
-  [
+  {
     ignore (translate_module_command ~name Parametricity.default_arity qid)
-  ]
+  }
 | [ "Parametricity" "Module" global(qid) "arity" integer(arity) ] ->
-  [
+  {
     ignore (translate_module_command arity qid)
-  ]
+  }
 | [ "Parametricity" "Module" global(qid) "as" ident(name) "arity" integer(arity) ] ->
-  [
+  {
     ignore (translate_module_command ~name arity qid)
-  ]
+  }
 | [ "Parametricity" "Module" global(qid) "arity" integer(arity) "as" ident(name)] ->
-  [
+  {
     ignore (translate_module_command ~name arity qid)
-  ]
+  }
 END
 
 VERNAC COMMAND EXTEND Realizer CLASSIFIED AS SIDEFF
 | [ "Realizer" constr(c) "as" ident(name) ":=" constr(t) ] ->
-  [
-    realizer_command Parametricity.default_arity (Some name) c t 
-  ]
+  {
+    realizer_command Parametricity.default_arity (Some name) c t
+  }
 | [ "Realizer" constr(c) "as" ident(name) "arity" integer(arity) ":=" constr(t) ] ->
-  [
-    realizer_command arity (Some name) c t 
-  ]
+  {
+    realizer_command arity (Some name) c t
+  }
 | [ "Realizer" constr(c) "arity" integer(arity) "as" ident(name) ":=" constr(t) ] ->
-  [
-    realizer_command arity (Some name) c t 
-  ]
+  {
+    realizer_command arity (Some name) c t
+  }
 END

--- a/src.8.10/debug.ml
+++ b/src.8.10/debug.ml
@@ -196,9 +196,9 @@ let debug_mutual_inductive_entry =
       match entry.mind_entry_universes with
       | Monomorphic_ind_entry ux ->
          Univ.pr_universe_context_set UnivNames.pr_with_global_universes ux
-      | Polymorphic_ind_entry ux ->
+      | Polymorphic_ind_entry (_,ux) ->
          Univ.pr_universe_context UnivNames.pr_with_global_universes ux
-      | Cumulative_ind_entry ci -> Univ.pr_cumulativity_info UnivNames.pr_with_global_universes ci
+      | Cumulative_ind_entry (_,ci) -> Univ.pr_cumulativity_info UnivNames.pr_with_global_universes ci
     in
     let mind_entry_private_pp =
       match entry.mind_entry_private with

--- a/src.8.10/declare_translation.ml
+++ b/src.8.10/declare_translation.ml
@@ -319,7 +319,7 @@ let translateFullName ~fullname arity (kername : Names.KerName.t) : string =
     (Names.ModPath.to_string
      @@ Names.KerName.modpath
      @@ kername) in
-  let plstr = Str.split (Str.regexp ("\.")) pstr in
+  let plstr = Str.split (Str.regexp ("\\.")) pstr in
   if fullname then
     (String.concat "_o_" (plstr@[nstr]))
   else nstr

--- a/src.8.10/dune
+++ b/src.8.10/dune
@@ -1,0 +1,10 @@
+(library
+ (name paramcoq)
+ (synopsis "Coq Plugin for Parametricity")
+ (public_name coq.plugins.paramcoq)
+ (libraries coq.plugins.ltac))
+
+(rule
+ (targets abstraction.ml)
+ (deps (:pp-file abstraction.mlg) )
+ (action (run coqpp %{pp-file})))


### PR DESCRIPTION
- port to new mlg preprocessor format [straightforward]
- fix w.r.t master; I will include paramcoq in Coq's CI after this is merged,
- add Dune file. A very convenient developer setup is now:

```
$ cd $coq_location
$ ln -s paramcoq/src.8.10
$ make -f Makefile.dune voboot
$ dune build @check # have fun!
```