### PR TITLE
Remove option `Parametricity Program`.

### DIFF
--- a/src/declare_translation.ml
+++ b/src/declare_translation.ml
@@ -63,8 +63,6 @@ let add_definition ~opaque ~hook ~kind ~tactic name env evd term typ =
 
 let declare_abstraction ?(opaque = false) ?(continuation = default_continuation) ?kind arity evdr env a name =
   Debug.debug_evar_map Debug.all "declare_abstraction, evd  = " env !evdr;
-  let program_mode_before = Flags.is_program_mode () in
-  Obligations.set_program_mode !Parametricity.program_mode;
   debug [`Abstraction] "declare_abstraction, a =" env !evdr a;
   let b = Retyping.get_type_of env !evdr a in
   debug [`Abstraction] "declare_abstraction, b =" env !evdr b;
@@ -98,8 +96,7 @@ let declare_abstraction ?(opaque = false) ?(continuation = default_continuation)
     | None -> Decl_kinds.Global, true, Decl_kinds.DefinitionBody Decl_kinds.Definition
     | Some kind -> kind in
   let tactic = snd (Relations.get_parametricity_tactic ()) in
-  add_definition ~tactic ~opaque ~kind ~hook name env evd a_R b_R;
-  Obligations.set_program_mode program_mode_before
+  add_definition ~tactic ~opaque ~kind ~hook name env evd a_R b_R
 
 
 let declare_inductive name ?(continuation = default_continuation) arity evd env (((mut_ind, _) as ind, inst)) =

--- a/src/parametricity.ml
+++ b/src/parametricity.ml
@@ -73,15 +73,6 @@ module CoqConstants = struct
     Program.papp evdref (fun () -> Coqlib.coq_reference msg ["Logic"; "ProofIrrelevance"] "proof_irrelevance") args
 end
 
-let program_mode = ref false
-let set_program_mode =
-   Goptions.declare_bool_option
-    { Goptions.optdepr  = false;
-      Goptions.optname  = "Parametricity Program";
-      Goptions.optkey   = ["Parametricity"; "Program"];
-      Goptions.optread  = (fun () -> !program_mode);
-      Goptions.optwrite = (:=) program_mode }
-
 let default_arity = 2
 
 let hyps_from_rel_context env =


### PR DESCRIPTION
I am afraid this option cannot be implemented after
https://github.com/coq/coq/pull/9410. It seems unused anyway.