### PR TITLE
Nix testing for v8.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,47 @@
-dist: trusty
-sudo: required
-language: generic
+opam: &OPAM
+  language: minimal
+  sudo: required
+  services: docker
+  install: |
+    # Prepare the COQ container
+    docker pull ${COQ_IMAGE}
+    docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
+    docker exec COQ /bin/bash --login -c "
+      # This bash script is double-quoted to interpolate Travis CI env vars:
+      echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex  # -e = exit on failure; -x = trace for debug
+      opam update -y
+      opam pin add ${CONTRIB_NAME} . -y --no-action
+      opam install ${CONTRIB_NAME} -y -j ${NJOBS} --deps-only
+      opam config list
+      opam repo list
+      opam list
+      "
+  script:
+  - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+  - |
+    docker exec COQ /bin/bash --login -c "
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex
+      sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
+      opam install ${CONTRIB_NAME} -v -y -j ${NJOBS}
+      "
+  - docker stop COQ  # optional
+  - echo -en 'travis_fold:end:script\\r'
 
-services:
-  - docker
+nix: &NIX
+  language: nix
+  script:
+  - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
-env:
-  matrix:
-  - COQ_IMAGE="coqorg/coq:8.10"
+matrix:
+  include:
 
-install: |
-  # Run the COQ container and display build metadata
-  docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/paramcoq -w /home/coq/paramcoq ${COQ_IMAGE}
-  docker exec COQ /bin/bash --login -c "
-    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
-    set -ex
-    opam config list
-    opam repo list
-    opam list
-    "
+  # Test supported versions of Coq via Nix
+  - env:
+    - COQ=https://github.com/coq/coq-on-cachix/tarball/v8.10
+    <<: *NIX
 
-script:
-- echo -e "${ANSI_YELLOW}Building paramcoq...${ANSI_RESET}" && echo -en 'travis_fold:start:paramcoq.build\\r'
-- |
-  docker exec COQ /bin/bash --login -c "
-    export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
-    set -ex
-    sudo chown -R coq:coq /home/coq/paramcoq
-    make
-    cd test-suite; make examples
-    "
-- docker stop COQ  # optional
-- echo -en 'travis_fold:end:paramcoq.build\\r'
+  # Test supported versions of Coq via OPAM
+

--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ pkgs.stdenv.mkDerivation {
 
   name = "paramcoq";
 
-  buildInputs = with coq.ocamlPackages; [ ocaml findlib ]
+  buildInputs = with coq.ocamlPackages; [ pkgs.which ocaml findlib ]
     ++ pkgs.lib.optionals shell [ merlin ocp-indent ocp-index ];
 
   propagatedBuildInputs = [
@@ -23,6 +23,14 @@ pkgs.stdenv.mkDerivation {
   ];
 
   src = if shell then null else ./.;
+
+  doCheck = true;
+
+  preCheck = "pushd test-suite";
+
+  checkTarget = "examples";
+
+  postCheck = "popd";
 
   installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,28 @@
+{ pkgs ? (import <nixpkgs> {}), coq-version-or-url, shell ? false }:
+
+let
+  coq-version-parts = builtins.match "([0-9]+).([0-9]+)" coq-version-or-url;
+  coqPackages =
+    if coq-version-parts == null then
+      pkgs.mkCoqPackages (import (fetchTarball coq-version-or-url) {})
+    else
+      pkgs."coqPackages_${builtins.concatStringsSep "_" coq-version-parts}";
+in
+
+with coqPackages;
+
+pkgs.stdenv.mkDerivation {
+
+  name = "paramcoq";
+
+  buildInputs = with coq.ocamlPackages; [ ocaml findlib ]
+    ++ pkgs.lib.optionals shell [ merlin ocp-indent ocp-index ];
+
+  propagatedBuildInputs = [
+    coq
+  ];
+
+  src = if shell then null else ./.;
+
+  installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+}

--- a/meta.yml
+++ b/meta.yml
@@ -1,0 +1,7 @@
+---
+shortname: paramcoq
+
+plugin: true
+
+tested_coq_nix_versions:
+- version_or_url: https://github.com/coq/coq-on-cachix/tarball/v8.10


### PR DESCRIPTION
I noticed that paramcoq CI tests are failing on v8.10 because the opam image for this branch does not exist yet: https://travis-ci.com/coq-community/paramcoq/builds/107312718

What I propose with this PR is to circumvent the problem by using coq-community's other vetted solution for CI testing, that relies on Nix. The point here is that it works as long as there is a v8.10 branch in the Coq repository, and still reuses cached binary builds of Coq.

The `.travis.yml` and `default.nix` files were generated automatically from the templates in https://github.com/coq-community/manifesto/tree/master/templates from a `meta.yml` file reduced to the bare minimum. The `.travis.yml` file is quite big because it also contains the infrastructure for building with opam even if it's not used in this case.