### PR TITLE
Adapt to Coq PR#13143: Pp.h does not take a (dummy) integer anymore.

### DIFF
--- a/src/debug.ml
+++ b/src/debug.ml
@@ -212,7 +212,7 @@ let debug_mutual_inductive_entry =
          "mind_entry_cumulative", mind_entry_cumul_pp;
          "mind_entry_private", mind_entry_private_pp]
     in
-    let res = (str "{") ++ h 140 (
+    let res = (str "{") ++ hov 140 (
     List.fold_left (fun acc (name, pp) ->
         field name pp acc) (mt ()) fields) ++ str "}" in
     Feedback.msg_notice res;
@@ -223,7 +223,7 @@ let debug_mutual_inductive_entry =
       SortSet.fold (fun sort accu ->
        accu ++ (Printer.pr_sort evd sort) ++ fnl ()) sorts (mt ())
     in
-    Feedback.msg_notice (h 100 sorts_pp)
+    Feedback.msg_notice (hov 100 sorts_pp)
   and pp_one_inductive_entry arities env_params entry =
     let params = Environ.rel_context env_params in
     let arities = List.map (fun (x, y) -> (x, Term.it_mkProd_or_LetIn y params)) arities in
@@ -254,7 +254,7 @@ let debug_mutual_inductive_entry =
          "mind_entry_consnames", mind_entry_consnames_pp;
          "mind_entry_lc", mind_entry_lc_pp ]
     in
-    str "{" ++ h 100 (
+    str "{" ++ hov 100 (
     List.fold_left (fun acc (name, pp) ->
         field name pp acc) (mt ()) fields) ++ str "}"
   in


### PR DESCRIPTION
PR coq/coq#13143 proposes to clarify that the integer argument of `Pp.h` boxes is irrelevant. There was three uses of `Pp.h` in paramcoq.

The h-boxes were called here with a very high integer. It might have been by irony knowing that the argument is dummy or to move the printing very far in the margin because it is intended to be debug printing to put far in the margin. The values were 100 and 140, so I assumed it was intended and I replaced the h-box by an hov-box.

To be merged synchronously with coq/coq#13143.

