### PR TITLE
use opam testing facilities to run tests in CI

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -23,31 +23,9 @@ jobs:
         with:
           opam_file: 'coq-paramcoq.opam'
           custom_image: ${{ matrix.image }}
-          custom_script: |
-            startGroup Print opam config
-              opam config list; opam repo list; opam list
-            endGroup
-            startGroup Build dependencies
-              opam pin add -n -y -k path $PACKAGE $WORKDIR
-              opam update -y
-              opam install -y -j 2 $PACKAGE --deps-only
-            endGroup
-            startGroup Build
-              opam install -y -v -j 2 $PACKAGE
-              opam list
-            endGroup
-            startGroup Workaround permission issue
-              sudo chown -R coq:coq .
-            endGroup
-            startGroup Run tests
-              make -C test-suite examples
-            endGroup
-            startGroup Uninstallation test
-              opam remove $PACKAGE
-            endGroup
-      - name: Revert permissions
-        if: ${{ always() }}
-        run: sudo chown -R 1001:116 .
+          export: 'OPAMWITHTEST'
+        env:
+          OPAMWITHTEST: 'true'
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/coq-paramcoq.opam
+++ b/coq-paramcoq.opam
@@ -14,6 +14,7 @@ The plugin is still in an experimental state. It is not very user friendly (lack
 
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
+run-test: [make "-C" "test-suite" "examples"]
 depends: [
   "coq" {= "dev" }
 ]

--- a/coq-paramcoq.opam
+++ b/coq-paramcoq.opam
@@ -13,8 +13,10 @@ The plugin is still in an experimental state. It is not very user friendly (lack
 """
 
 build: [make "-j%{jobs}%" ]
-install: [make "install"]
-run-test: [make "-C" "test-suite" "examples"]
+install: [
+  [make "install"]
+  [make "-C" "test-suite" "examples"] {with-test}
+]
 depends: [
   "coq" {= "dev" }
 ]


### PR DESCRIPTION
The current CI configuration could prove a handful to maintain, so here I use opam testing facilities, already used by projects such as Equations, to simplify it.