### PR TITLE
introduce Params.v file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Generated Makefile
-/Makefile.coq
-/Makefile.coq.conf
+Makefile.coq
+Makefile.coq.conf
+
+# Dune
+_build
 
 # Make dependencies
 *.d

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
-# -*- Makefile -*-
-.PHONY: coq clean
+all: Makefile.coq
+	@+$(MAKE) -f Makefile.coq all
 
-coq:: Makefile.coq
-	$(MAKE) -f Makefile.coq
+clean: Makefile.coq
+	@+$(MAKE) -f Makefile.coq cleanall
+	@rm -f Makefile.coq Makefile.coq.conf
 
-Makefile.coq: Make.cfg
-	coq_makefile -f Make.cfg -o Makefile.coq
+Makefile.coq: _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
 
-distclean:
-	rm -f Makefile.coq Makefile.coq.conf Makefile.coq.bak .coqdeps.d
+force _CoqProject Makefile: ;
 
-install:
-	$(MAKE) -f Makefile.coq install
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
+
+.PHONY: all clean force

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,3 +1,4 @@
+-R theories Param
 -R src Param
 -I src
 src/debug.ml
@@ -6,3 +7,4 @@ src/relations.ml
 src/declare_translation.ml
 src/abstraction.mlg
 src/paramcoq.mlpack
+theories/Param.v

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.5)
+(using coq 0.2)
+(name paramcoq)

--- a/src/dune
+++ b/src/dune
@@ -1,11 +1,8 @@
 (library
  (name paramcoq)
- (public_name coq.plugins.paramcoq)
- (synopsis "Coq Plugin for Parametricity")
- (flags :standard -warn-error -3)
- (libraries coq.plugins.ltac))
+ (public_name coq-paramcoq.plugin)
+ (synopsis "Plugin for generating parametricity statements to perform refinement proofs")
+ (flags :standard -rectypes -w -9-27)
+ (libraries coq-core.plugins.ltac))
 
-(rule
- (targets abstraction.ml)
- (deps (:pp-file abstraction.mlg) )
- (action (run coqpp %{pp-file})))
+(coq.pp (modules abstraction))

--- a/theories/Param.v
+++ b/theories/Param.v
@@ -1,0 +1,1 @@
+Declare ML Module "paramcoq".

--- a/theories/dune
+++ b/theories/dune
@@ -1,0 +1,5 @@
+(coq.theory
+ (name Param)
+ (package coq-paramcoq)
+ (synopsis "Plugin for generating parametricity statements to perform refinement proofs")
+ (libraries coq-paramcoq.plugin))


### PR DESCRIPTION
As highlighted by #56, there is no pure Coq interface to this plugin. This means that a user has to know and perform the declaration:
```coq
Declare ML Module "paramcoq".
```
This is not likely to be figured out except by advanced users. In this PR, I introduce a Coq interface, so that users can write
```coq
From Param Require Import Param.
```
to get access to plugin commands. This has the side-effect of making the `coqdep` warning from #56 go away.

For easier development, I also introduce a `_CoqProject` file, fix the Dune-based build, and use a coq-community standard makefile. As far as I can tell, all functionality is completely untouched.

If this PR is accepted, I will do a separate PR with improved documentation.