### PR TITLE
Refine documentation

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Docker CI
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ _build
 
 # coqpp generated file
 src/abstraction.ml
+
+# lia cache
+.lia.cache

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ is usable enough to "translate" a large chunk of the standard library.
 - Coq-community maintainer(s):
   - Pierre Roux ([**@proux01**](https://github.com/proux01))
 - License: [MIT License](LICENSE)
-- Compatible Coq versions: The master branch tracks the development version of Coq, see releases for compatibility with released versions of Coq.
-
+- Compatible Coq versions: The master branch tracks the development version of Coq, see releases for compatibility with released versions of Coq
 - Additional dependencies: none
 - Coq namespace: `Param`
 - Related publication(s):

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Realizer <constant_or_variable> [as <name>] [arity <n>] := <term>.
 ```
 
 Note that translating a term or module may lead to proof obligations (for some
-fixpoints and opaque terms if you did not import `ProofIrrelevence`). You can
+fixpoints and opaque terms if you did not import `ProofIrrelevence`). You need to
 declare a tactic to solve such proof obligations:
 ```coq
 [Global|Local] Parametricity Tactic := <tactic>.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
+<!---
+This file was generated from `meta.yml`, please do not edit manually.
+Follow the instructions on https://github.com/coq-community/templates to regenerate.
+--->
 # Paramcoq
 
-[![CI][action-shield]][action-link]
+[![Docker CI][docker-action-shield]][docker-action-link]
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Zulip][zulip-shield]][zulip-link]
 [![DOI][doi-shield]][doi-link]
 
-[action-shield]: https://github.com/coq-community/paramcoq/workflows/CI/badge.svg?branch=master
-[action-link]: https://github.com/coq-community/paramcoq/actions?query=workflow%3ACI
+[docker-action-shield]: https://github.com/coq-community/paramcoq/workflows/Docker%20CI/badge.svg?branch=master
+[docker-action-link]: https://github.com/coq-community/paramcoq/actions?query=workflow:"Docker%20CI"
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
 [contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
@@ -22,8 +26,11 @@
 [doi-shield]: https://zenodo.org/badge/DOI/10.4230/LIPIcs.CSL.2012.399.svg
 [doi-link]: https://doi.org/10.4230/LIPIcs.CSL.2012.399
 
-The plugin is still in an experimental state. It is not very user friendly (lack of good error messages) and still contains bugs. But is useable enough to "translate" a large chunk of standard library.
-
+A Coq plugin providing commands for generating parametricity statements.
+Typical applications of such statements are in data refinement proofs.
+Note that the plugin is still in an experimental state - it is not very user
+friendly (lack of good error messages) and still contains bugs. But it
+is usable enough to "translate" a large chunk of the standard library.
 
 ## Meta
 
@@ -37,7 +44,7 @@ The plugin is still in an experimental state. It is not very user friendly (lack
   - Matthieu Sozeau
 - Coq-community maintainer(s):
   - Pierre Roux ([**@proux01**](https://github.com/proux01))
-- License: [MIT](LICENSE)
+- License: [MIT License](LICENSE)
 - Compatible Coq versions: The master branch tracks the development version of Coq, see releases for compatibility with released versions of Coq.
 
 - Additional dependencies: none
@@ -65,37 +72,57 @@ make install
 ```
 
 
-Available commands
-------------------
+## Usage and Commands
 
-The default arity is 2.
+To load the plugin and make its commands available:
+```coq
+From Param Require Import Param.
+```
 
-- Parametricity *ident* as *name* [arity *n*].
+The command scheme for named translations is:
+```
+Parametricity <ident> as <name> [arity <n>].
+```
+For example, the following command generates a translation named `my_param`
+of the constant or inductive `my_id` with arity 2 (the default):
+```coq
+Parametricity my_id as my_param.
+```
 
-Declare the translation named *name* from the translation of the constant or inductive *ident*.
+The command scheme for automatically named translations is:
+```coq
+Parametricity [Recursive] <ident> [arity <n>] [qualified].
+```
+Such commands generate and name translations based on the given identifier.
+The `Recursive` option can be used to recursively translate all the constants
+and inductives which are used by the constant or inductive with the given
+identifier. The `qualified` option allows you to use a qualified default name
+for the translated constants and inductives. The default name then has the form
+`Module_o_Submodule_o_my_id` if the identifier `my_id` is declared in the
+`Module.Submodule` namespace.
 
-- Parametricity [Recursive] *ident* [arity *n*] [qualified].
+Instead of using identifiers, you can provide explicit terms to translate,
+according to the following command scheme:
+```coq
+Parametricity Translation <term> [as <name>] [arity <n>].
+```
+This defines a new constant containing the parametricity translation of
+the given term.
 
-The default name for the translation of the constant or inductive *ident* is automatically generated (from its unqualified name).
-You can use the `Recursive` option to recursively translate all the constants and inductives which are used by *ident*.
-You can use the `qualified` option to use a qualified default name for the translated constants and inductives. The default name then has the form `Module_o_Submodule_o_ident` if *ident* lies in the `Module.Submodule` namespace.
+To recursively translate everything in a module:
+```coq
+Parametricity Module <module_path>.
+```
 
-- Parametricity Translation *term* [as *name*] [arity *n*].
+When translating terms containing section variables or axioms,
+it may be useful to declare a term to be the translation of a constant:
+```coq
+Realizer <constant_or_variable> [as <name>] [arity <n>] := <term>.
+```
 
-Define a new constant named *name* obtained by computing the parametricity translation of *term*.
-
-- Parametricity Module *modulepath*.
-
-Recursively translate everything in a module.
-
-- Realizer *constant or variable* [as *name*] [arity *n*] := *term*.
-
-Declare *term* to be the translation of a constant.
-Useful to translate terms containing section variables, or axioms.
-
-Note that both translating a term or module may lead to proof obligations (for some fixpoints and opaque terms if you did not import `ProofIrrelevence`).
-
-- [Global | Local] Parametricity Tactic := t.
-
-Use the tactic t to solve proof obligations generated by the `Parametricity` command.
-
+Note that translating a term or module may lead to proof obligations (for some
+fixpoints and opaque terms if you did not import `ProofIrrelevence`). You can
+declare a tactic to solve such proof obligations:
+```coq
+[Global|Local] Parametricity Tactic := <tactic>.
+```

--- a/coq-paramcoq.opam
+++ b/coq-paramcoq.opam
@@ -9,10 +9,13 @@ license: "MIT"
 
 synopsis: "Plugin for generating parametricity statements to perform refinement proofs"
 description: """
-The plugin is still in an experimental state. It is not very user friendly (lack of good error messages) and still contains bugs. But is useable enough to "translate" a large chunk of standard library.
-"""
+A Coq plugin providing commands for generating parametricity statements.
+Typical applications of such statements are in data refinement proofs.
+Note that the plugin is still in an experimental state - it is not very user
+friendly (lack of good error messages) and still contains bugs. But it
+is usable enough to "translate" a large chunk of the standard library."""
 
-build: [make "-j%{jobs}%" ]
+build: [make "-j%{jobs}%"]
 install: [
   [make "install"]
   [make "-C" "test-suite" "examples"] {with-test}

--- a/meta.yml
+++ b/meta.yml
@@ -1,81 +1,120 @@
+---
 fullname: Paramcoq
 shortname: paramcoq
 organization: coq-community
 community: true
 action: true
-synopsis: Plugin for generating parametricity statements to perform refinement proofs
-description: >
-  The plugin is still in an experimental state. It is not very user
-  friendly (lack of good error messages) and still contains bugs. But
-  is useable enough to "translate" a large chunk of standard library.
+plugin: true
 doi: 10.4230/LIPIcs.CSL.2012.399
+branch: master
+
+synopsis: Plugin for generating parametricity statements to perform refinement proofs
+
+description: |-
+  A Coq plugin providing commands for generating parametricity statements.
+  Typical applications of such statements are in data refinement proofs.
+  Note that the plugin is still in an experimental state - it is not very user
+  friendly (lack of good error messages) and still contains bugs. But it
+  is usable enough to "translate" a large chunk of the standard library.
+
 publications:
-  - pub_title: Parametricity in an Impredicative Sort
-    pub_url: https://hal.archives-ouvertes.fr/hal-00730913/
-    pub_doi: 10.4230/LIPIcs.CSL.2012.399
+- pub_title: Parametricity in an Impredicative Sort
+  pub_url: https://hal.archives-ouvertes.fr/hal-00730913/
+  pub_doi: 10.4230/LIPIcs.CSL.2012.399
+
 authors:
-  - name: Chantal Keller
-    initial: true
-  - name: Marc Lasson
-    initial: true
-  - name: Abhishek Anand
-  - name: Pierre Roux
-  - name: Emilio Jesús Gallego Arias
-  - name: Cyril Cohen
-  - name: Matthieu Sozeau
+- name: Chantal Keller
+  initial: true
+- name: Marc Lasson
+  initial: true
+- name: Abhishek Anand
+- name: Pierre Roux
+- name: Emilio Jesús Gallego Arias
+- name: Cyril Cohen
+- name: Matthieu Sozeau
+
 maintainers:
-  - name: Pierre Roux
-    nickname: proux01
+- name: Pierre Roux
+  nickname: proux01
+
 license:
-  fullname: MIT
+  fullname: MIT License
   identifier: MIT
+
 supported_coq_versions:
   text: >
     The master branch tracks the development version of Coq, see
     releases for compatibility with released versions of Coq.
   opam: '{= "dev" }'
-plugin: true
+
 categories:
-  - name: 'Miscellaneous/Coq Extensions'
+- name: 'Miscellaneous/Coq Extensions'
+
 keywords:
-  - name: paramcoq
-  - name: parametricity
-  - name: ocaml module
+- name: paramcoq
+- name: parametricity
+- name: ocaml module
+
 namespace: Param
+
 opam-file-maintainer: 'Pierre Roux <pierre.roux@onera.fr>'
+
 tested_coq_opam_versions:
-  - version: 'dev'
-documentation: |
-  Available commands
-  ------------------
+- version: 'dev'
 
-  The default arity is 2.
+documentation: |-
+  ## Usage and Commands
 
-  - Parametricity *ident* as *name* [arity *n*].
+  To load the plugin and make its commands available:
+  ```coq
+  From Param Require Import Param.
+  ```
 
-  Declare the translation named *name* from the translation of the constant or inductive *ident*.
+  The command scheme for named translations is:
+  ```
+  Parametricity <ident> as <name> [arity <n>].
+  ```
+  For example, the following command generates a translation named `my_param`
+  of the constant or inductive `my_id` with arity 2 (the default):
+  ```coq
+  Parametricity my_id as my_param.
+  ```
 
-  - Parametricity [Recursive] *ident* [arity *n*] [qualified].
+  The command scheme for automatically named translations is:
+  ```coq
+  Parametricity [Recursive] <ident> [arity <n>] [qualified].
+  ```
+  Such commands generate and name translations based on the given identifier.
+  The `Recursive` option can be used to recursively translate all the constants
+  and inductives which are used by the constant or inductive with the given
+  identifier. The `qualified` option allows you to use a qualified default name
+  for the translated constants and inductives. The default name then has the form
+  `Module_o_Submodule_o_my_id` if the identifier `my_id` is declared in the
+  `Module.Submodule` namespace.
 
-  The default name for the translation of the constant or inductive *ident* is automatically generated (from its unqualified name).
-  You can use the `Recursive` option to recursively translate all the constants and inductives which are used by *ident*.
-  You can use the `qualified` option to use a qualified default name for the translated constants and inductives. The default name then has the form `Module_o_Submodule_o_ident` if *ident* lies in the `Module.Submodule` namespace.
+  Instead of using identifiers, you can provide explicit terms to translate,
+  according to the following command scheme:
+  ```coq
+  Parametricity Translation <term> [as <name>] [arity <n>].
+  ```
+  This defines a new constant containing the parametricity translation of
+  the given term.
 
-  - Parametricity Translation *term* [as *name*] [arity *n*].
+  To recursively translate everything in a module:
+  ```coq
+  Parametricity Module <module_path>.
+  ```
 
-  Define a new constant named *name* obtained by computing the parametricity translation of *term*.
+  When translating terms containing section variables or axioms,
+  it may be useful to declare a term to be the translation of a constant:
+  ```coq
+  Realizer <constant_or_variable> [as <name>] [arity <n>] := <term>.
+  ```
 
-  - Parametricity Module *modulepath*.
-
-  Recursively translate everything in a module.
-
-  - Realizer *constant or variable* [as *name*] [arity *n*] := *term*.
-
-  Declare *term* to be the translation of a constant.
-  Useful to translate terms containing section variables, or axioms.
-
-  Note that both translating a term or module may lead to proof obligations (for some fixpoints and opaque terms if you did not import `ProofIrrelevence`).
-
-  - [Global | Local] Parametricity Tactic := t.
-
-  Use the tactic t to solve proof obligations generated by the `Parametricity` command.
+  Note that translating a term or module may lead to proof obligations (for some
+  fixpoints and opaque terms if you did not import `ProofIrrelevence`). You can
+  declare a tactic to solve such proof obligations:
+  ```coq
+  [Global|Local] Parametricity Tactic := <tactic>.
+  ```
+---

--- a/meta.yml
+++ b/meta.yml
@@ -42,9 +42,9 @@ license:
   identifier: MIT
 
 supported_coq_versions:
-  text: >
+  text: >-
     The master branch tracks the development version of Coq, see
-    releases for compatibility with released versions of Coq.
+    releases for compatibility with released versions of Coq
   opam: '{= "dev" }'
 
 categories:


### PR DESCRIPTION
Document how to cleanly load the plugin and explain its commands in a more structured way using GitHub markdown facilities. Use more standard placement of files and generate some boilerplate.