### PR TITLE
Adapt to coq/coq#15003 (user_err has no hdr argument)

### DIFF
--- a/src/parametricity.ml
+++ b/src/parametricity.ml
@@ -24,7 +24,7 @@ let mkArrow x y = mkArrow x Sorts.Relevant y
 
 let mkannot x = Context.make_annot x Sorts.Relevant
 
-let error msg = CErrors.user_err ~hdr:"Parametricity plugin" msg
+let error msg = CErrors.user_err msg
 
 let new_evar_compat env evd uf_opaque_stmt =
   Evarutil.new_evar env evd uf_opaque_stmt


### PR DESCRIPTION
Backwards compatible (hdr was optional)