### PR TITLE
add back opam package testing in CI

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           opam_file: 'coq-paramcoq.opam'
           custom_image: ${{ matrix.image }}
+          export: 'OPAMWITHTEST'
+        env:
+          OPAMWITHTEST: 'true'
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme


### PR DESCRIPTION
I mistakenly removed opam package tests from being run in Docker-based CI in the v8.14 branch. This reenables the testing.