### PR TITLE
[coq] Use findlib name in DECLARE PLUGIN

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:dev'
+          - 'coqorg/coq:dev-ocaml-4.13-flambda'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/src/abstraction.mlg
+++ b/src/abstraction.mlg
@@ -12,7 +12,7 @@
 
 }
 
-DECLARE PLUGIN "parametricity"
+DECLARE PLUGIN "coq-paramcoq.plugin"
 
 {
 open Ltac_plugin


### PR DESCRIPTION
After some stronger invariant upstream, the name here has to match the
name used in `Declare ML Module`.