### PR TITLE
Use of mkConstU and use of the new names of decompose_lam & cie (#15582)

### DIFF
--- a/src/declare_translation.ml
+++ b/src/declare_translation.ml
@@ -238,8 +238,11 @@ and declare_module ?(continuation = ignore) ?name arity mb  =
           state] *)
        let env = Global.env () in
        let evd = Evd.from_env env in
+       let evd, ucst =
+          Evd.(with_context_set univ_rigid evd (UnivGen.fresh_constant_instance env cst))
+       in
        let evdr = ref evd in
-       ignore(declare_realizer ~continuation arity evdr env None (mkConst cst))
+       ignore(declare_realizer ~continuation arity evdr env None (mkConstU (fst ucst, EInstance.make (snd ucst))))
 
      | (lab, SFBconst cb) ->
        let opaque =


### PR DESCRIPTION
This PR addresses some warnings while compiling paramcoq with recent Coq (such as 8.18):
- use of `mkConstU` so as to deal with universes
- some renamings from coq/coq#15582