### PR TITLE
Adapt to Coq stdlib renamings and fixes a mispelled constructor

### DIFF
--- a/test-suite/ListQueue.v
+++ b/test-suite/ListQueue.v
@@ -124,7 +124,7 @@ Lemma rev_app :
     rev (l1 ++ l2) = rev l2 ++ rev l1.
 induction l1.
 intro; symmetry; apply app_nil_r.
-intro; simpl; rewrite IHl1; rewrite app_ass.
+intro; simpl; rewrite IHl1; rewrite app_assoc.
 reflexivity.
 Defined.
 

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -19,7 +19,7 @@ bug%.vo: bug%.v Parametricity.vo
 
 # native eats too much memory, see eg https://gitlab.com/coq/coq/-/jobs/1144081161
 %.vo: %.v
-	$(COQC) $(PARAMLIBS) -native-compiler no $<
+	$(COQC) $(PARAMLIBS) -R . "" -native-compiler no $<
 
 ide:: Parametricity.vo
 	$(COQBIN)coqide -debug $(PARAMLIBS) $(EXAMPLES)

--- a/test-suite/bug3.v
+++ b/test-suite/bug3.v
@@ -17,7 +17,7 @@ Fixpoint subS (n m : nat) {struct n} : nat :=
 Definition modS :=
 fun x y : nat => match y with
                  | 0 => match (1 mod 0) with | 0 => 0 | _ => x end
-                 | S y' => subS y' (snd (divmod x y' 0 y'))
+                 | S y' => subS y' (snd (Nat.divmod x y' 0 y'))
                  end.
 
 Lemma subS_same : forall n m, subS  n m = Nat.sub n m.

--- a/test-suite/bug5.v
+++ b/test-suite/bug5.v
@@ -21,7 +21,7 @@ Fixpoint subS (n m : nat) {struct n} : nat :=
 Definition modS :=
 fun x y : nat => match y with
                  | 0 => y
-                 | S y' => subS y' (snd (divmod x y' 0 y'))
+                 | S y' => subS y' (snd (Nat.divmod x y' 0 y'))
                  end.
 
 (*

--- a/test-suite/example.v
+++ b/test-suite/example.v
@@ -61,7 +61,7 @@ boolfun_R = fun f1 f2 : bool -> bool =>
 Definition negb (x : bool) := 
   match x with 
    | true => false
-   | fale => true
+   | false => true
   end. 
 Parametricity negb.
 Check negb_R.


### PR DESCRIPTION
This PR addresses two stdlib renamings while compiling paramcoq's examples with recent Coq (such as 8.18): `app_assoc` and `Nat.divmod`.

It also fixes a mispelling which was supposingly unintended (revealed by a new Coq warning).